### PR TITLE
Add plugin framework and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Basic plugin framework under `stego_plugins` with OutGuess adapter.
+- `stego.py` CLI with plugin command.
+- Minimal Flask API (`api.py`) exposing `/api/v3/plugin/<tool>/<action>`.
+- Pytest unit test for missing OutGuess binary.
+- Requirements update and setup script.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | **Detection** | StegExpose, Zsteg & StegSeek integration |
 | **Metadata** | EXIF / IPTC inject / wipe with ExifTool |
 | **Forensics** | Binwalk & pdf‑parser one‑click payload carving |
-| **Automation** | Plugin runner, async CLI, REST `/api/v3/*` |
+| **Automation** | Plugin runner with auto tool detection, async CLI, REST `/api/v3/*` |
 | **GUI** | Advanced tab + detection pane, progress bars |
 | **CI / DevOps** | GitHub Actions, Docker, coverage badge |
 | **Install** | `./install-apt.sh` or `./install-brew.sh` – one line |
@@ -38,7 +38,10 @@ stego.py plugin --tool outguess \
        --action embed \
        -i carrier.jpg -p secret.txt -o secret.jpg
 
-# 4. Detect hidden content in bulk
+# 4. Run the REST API
+python api.py
+
+# 5. Detect hidden content in bulk
 stego.py detect --in ./suspicious_samples --tool stegxpose --report report.csv
 
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from flask import Flask, jsonify, request, send_file
+
+from stego_plugins import OutGuess, PluginError
+
+app = Flask(__name__)
+
+
+@app.post("/api/v3/plugin/<tool>/<action>")
+def plugin_route(tool: str, action: str):
+    args = request.json or {}
+    infile = Path(args.get("infile", ""))
+    payload = Path(args.get("payload", "")) if args.get("payload") else None
+    output = Path(args.get("output", "output.bin"))
+
+    if tool != "outguess":
+        return jsonify({"error": "unsupported tool"}), 400
+
+    try:
+        plugin = OutGuess()
+    except PluginError as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    async def run():
+        try:
+            if action == "embed":
+                await plugin.embed(infile, payload, output)
+            elif action == "extract":
+                await plugin.extract(infile, output)
+            else:
+                return jsonify({"error": "unsupported action"}), 400
+            return None
+        except PluginError as exc:
+            return str(exc)
+
+    loop = asyncio.new_event_loop()
+    err = loop.run_until_complete(run())
+    loop.close()
+    if err:
+        return jsonify({"error": err}), 500
+    return send_file(output, as_attachment=True)
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/proposals.md
+++ b/proposals.md
@@ -1,0 +1,5 @@
+# Future Proposals
+
+- Expand plugin adapters for Steghide, Zsteg and StegExpose.
+- Integrate advanced detection pane in the GUI with progress indicators.
+- Provide Docker container and GitHub Actions workflow for automated testing and linting.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
-psutil
 colorama
+psutil
+cryptography
+PyPDF2
+qrcode
+pyzbar
+Pillow
+Flask
+pytest

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt

--- a/stego.py
+++ b/stego.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import argparse
+from pathlib import Path
+
+from stego_plugins import OutGuess, PluginError
+
+
+async def run_plugin(args: argparse.Namespace) -> None:
+    tool = args.tool
+    action = args.action
+
+    if tool == "outguess":
+        plugin = OutGuess()
+    else:
+        raise SystemExit(f"Unsupported tool: {tool}")
+
+    try:
+        if action == "embed":
+            await plugin.embed(Path(args.infile), Path(args.payload), Path(args.output))
+            print("Embed successful")
+        elif action == "extract":
+            await plugin.extract(Path(args.infile), Path(args.output))
+            print("Extraction successful")
+        else:
+            raise SystemExit(f"Unsupported action: {action}")
+    except PluginError as exc:
+        print(f"Error: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Steganography Tool")
+    subparsers = parser.add_subparsers(dest="command")
+
+    plugin_parser = subparsers.add_parser("plugin", help="Run external stego tools")
+    plugin_parser.add_argument("--tool", required=True, help="Tool name")
+    plugin_parser.add_argument("--action", required=True, choices=["embed", "extract"])
+    plugin_parser.add_argument(
+        "-i", "--infile", required=True, help="Input carrier file"
+    )
+    plugin_parser.add_argument("-p", "--payload", help="Payload file for embed")
+    plugin_parser.add_argument("-o", "--output", required=True, help="Output file")
+
+    args = parser.parse_args()
+    if args.command == "plugin":
+        asyncio.run(run_plugin(args))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/stego_plugins/__init__.py
+++ b/stego_plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Pluggable external steganography tool adapters."""
+
+from .base import ExternalTool, PluginError
+from .outguess import OutGuess
+
+__all__ = ["ExternalTool", "PluginError", "OutGuess"]

--- a/stego_plugins/base.py
+++ b/stego_plugins/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import List
+
+
+class PluginError(Exception):
+    """Raised when a plugin operation fails."""
+
+
+class ExternalTool:
+    """Base class for external steganography tools."""
+
+    name: str
+    executable: str
+
+    def __init__(self) -> None:
+        if not shutil.which(self.executable):
+            raise PluginError(f"Required tool '{self.executable}' not found in PATH")
+
+    async def run(self, args: List[str]) -> asyncio.subprocess.Process:
+        process = await asyncio.create_subprocess_exec(
+            self.executable,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        return process
+
+    async def embed(self, *args: str) -> str:
+        raise NotImplementedError
+
+    async def extract(self, *args: str) -> str:
+        raise NotImplementedError

--- a/stego_plugins/outguess.py
+++ b/stego_plugins/outguess.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import List
+
+from .base import ExternalTool, PluginError
+
+
+class OutGuess(ExternalTool):
+    """Adapter for the `outguess` steganography tool."""
+
+    name = "outguess"
+    executable = "outguess"
+
+    async def embed(self, carrier: Path, payload: Path, output: Path) -> str:
+        process = await self.run(["-d", str(payload), str(carrier), str(output)])
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise PluginError(stderr.decode().strip())
+        return stdout.decode().strip()
+
+    async def extract(self, carrier: Path, output: Path) -> str:
+        process = await self.run(["-r", str(carrier), str(output)])
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise PluginError(stderr.decode().strip())
+        return stdout.decode().strip()

--- a/tests/test_outguess.py
+++ b/tests/test_outguess.py
@@ -1,0 +1,8 @@
+import pytest
+from stego_plugins import OutGuess, PluginError
+
+
+def test_outguess_missing_binary(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    with pytest.raises(PluginError):
+        OutGuess()


### PR DESCRIPTION
## Summary
- implement new plugin framework under `stego_plugins`
- add OutGuess adapter
- expose plugin functionality through new `stego.py` CLI and Flask `api.py`
- provide pytest for plugin detection
- document changes in README and CHANGELOG
- update requirements and provide setup script

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e50a13254832b99349001d36cbfc9

## Summary by Sourcery

Introduce a plugin framework for external steganography tools, starting with an OutGuess adapter, and expose embed/extract operations through both a new CLI and a Flask-based API

New Features:
- Introduce a pluggable framework under stego_plugins with an OutGuess adapter
- Add stego.py CLI with a plugin command for embedding and extracting payloads
- Expose plugin functionality via a Flask-based REST API at /api/v3/plugin/<tool>/<action>
- Add setup.sh script to automate virtual environment setup and dependency installation

Build:
- Update requirements.txt with additional dependencies
- Add setup.sh script to streamline project setup

Documentation:
- Update README with plugin runner, async CLI usage, and REST API steps
- Add CHANGELOG entries for the new plugin framework
- Introduce proposals.md outlining future enhancements

Tests:
- Add pytest test to verify error handling when the OutGuess binary is missing