### PR TITLE
Enhance plugin handling with discovery and CLI progress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["pytest", "-q"]

--- a/api.py
+++ b/api.py
@@ -5,28 +5,9 @@ from pathlib import Path
 
 from flask import Flask, jsonify, request, send_file
 
-from stego_plugins import (
-    OutGuess,
-    StegHide,
-    Zsteg,
-    StegExpose,
-    Aletheia,
-    StegDetector,
-    AudioLSB,
-    Watermark,
-    PluginError,
-)
+from stego_plugins import discover_plugins, PluginError
 
-PLUGIN_MAP = {
-    "outguess": OutGuess,
-    "steghide": StegHide,
-    "zsteg": Zsteg,
-    "stegexpose": StegExpose,
-    "aletheia": Aletheia,
-    "steg-detector": StegDetector,
-    "audio-lsb": AudioLSB,
-    "watermark": Watermark,
-}
+PLUGIN_MAP = discover_plugins()
 
 app = Flask(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ numpy
 opencv-python
 pydub
 dnspython
+tqdm

--- a/stego.py
+++ b/stego.py
@@ -5,28 +5,24 @@ import asyncio
 import argparse
 from pathlib import Path
 
-from stego_plugins import (
-    OutGuess,
-    StegHide,
-    Zsteg,
-    StegExpose,
-    Aletheia,
-    StegDetector,
-    AudioLSB,
-    Watermark,
-    PluginError,
-)
+from stego_plugins import discover_plugins, PluginError
+from tqdm import tqdm
 
-PLUGIN_MAP = {
-    "outguess": OutGuess,
-    "steghide": StegHide,
-    "zsteg": Zsteg,
-    "stegexpose": StegExpose,
-    "aletheia": Aletheia,
-    "steg-detector": StegDetector,
-    "audio-lsb": AudioLSB,
-    "watermark": Watermark,
-}
+
+async def run_with_progress(coro: asyncio.Future, desc: str) -> str:
+    """Display a simple progress bar while awaiting a coroutine."""
+    task = asyncio.create_task(coro)
+    with tqdm(total=100, desc=desc) as prog:
+        while not task.done():
+            await asyncio.sleep(0.1)
+            prog.update(1)
+            if prog.n >= 100:
+                prog.n = 0
+                prog.refresh()
+        prog.update(100 - prog.n)
+    return await task
+
+PLUGIN_MAP = discover_plugins()
 
 
 async def run_plugin(args: argparse.Namespace) -> None:
@@ -40,13 +36,21 @@ async def run_plugin(args: argparse.Namespace) -> None:
 
     try:
         if action == "embed":
-            await plugin.embed(Path(args.infile), Path(args.payload), Path(args.output))
+            await run_with_progress(
+                plugin.embed(Path(args.infile), Path(args.payload), Path(args.output)),
+                f"{tool} embed",
+            )
             print("Embed successful")
         elif action == "extract":
-            await plugin.extract(Path(args.infile), Path(args.output))
+            await run_with_progress(
+                plugin.extract(Path(args.infile), Path(args.output)),
+                f"{tool} extract",
+            )
             print("Extraction successful")
         elif action == "detect" and hasattr(plugin, "detect"):
-            result = await plugin.detect(Path(args.infile))
+            result = await run_with_progress(
+                plugin.detect(Path(args.infile)), f"{tool} detect"
+            )
             print(result)
         else:
             raise SystemExit(f"Unsupported action: {action}")

--- a/stego_plugins/__init__.py
+++ b/stego_plugins/__init__.py
@@ -1,6 +1,34 @@
-"""Pluggable steganography tool adapters."""
+"""Pluggable steganography tool adapters with dynamic discovery."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from types import ModuleType
+from typing import Dict, Type
 
 from .base import ExternalTool, PluginError
+
+
+def _iter_modules() -> list[ModuleType]:
+    for _, name, _ in pkgutil.iter_modules(__path__):
+        yield importlib.import_module(f"{__name__}.{name}")
+
+
+def discover_plugins() -> Dict[str, Type]:
+    """Return a mapping of plugin name to class by scanning this package."""
+    plugins: Dict[str, Type] = {}
+    for module in _iter_modules():
+        for obj in module.__dict__.values():
+            if inspect.isclass(obj) and getattr(obj, "name", None):
+                if obj is ExternalTool or obj is PluginError:
+                    continue
+                plugins[obj.name] = obj
+    return plugins
+
+
+# Import common plugins so they remain accessible at module level
 from .outguess import OutGuess
 from .steghide import StegHide
 from .zsteg import Zsteg
@@ -24,4 +52,5 @@ __all__ = [
     "AudioLSB",
     "Watermark",
     "NetworkStego",
+    "discover_plugins",
 ]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,8 @@
 from stego import PLUGIN_MAP
-from stego_plugins import OutGuess
+from stego_plugins import OutGuess, discover_plugins
 
 
 def test_plugin_map():
+    discovered = discover_plugins()
     assert PLUGIN_MAP["outguess"] is OutGuess
+    assert "outguess" in discovered


### PR DESCRIPTION
## Summary
- support dynamic plugin discovery in `stego_plugins`
- expose discovered plugins to the CLI and API
- add CLI progress bars for plugin operations
- update tests to cover discovery
- include Dockerfile and requirement for `tqdm`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not connect to pypi.org)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685e5c0e9038832b8821e87ca5c61253

## Summary by Sourcery

Enable dynamic plugin discovery and CLI progress reporting for stego_plugins, update tests and dependencies, and add a Dockerfile for containerized testing.

New Features:
- Enable dynamic plugin discovery in CLI and API using discover_plugins
- Integrate asyncio-based progress bars for plugin embed/extract/detect operations using tqdm

Enhancements:
- Update tests to validate dynamic plugin discovery and PLUGIN_MAP consistency
- Add tqdm to requirements for progress bar support

Deployment:
- Add Dockerfile for building a container and running tests

Tests:
- Enhance test_loader to assert that PLUGIN_MAP entries match discover_plugins output