### PR TITLE
Update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ cd Steganography-Tool
 
 # Install dependencies
 pip install -r requirements.txt
+
+# Or run the helper script to create a virtual environment
+bash setup.sh
 ```
 
 ### Option 2: Download ZIP

--- a/proposals.md
+++ b/proposals.md
@@ -14,3 +14,6 @@
 - Package the tool using PyInstaller for easy distribution.
 - Implement optional in-memory encryption for sensitive payloads.
 - Provide a plugin marketplace to share community extensions.
+- Add batch processing mode for entire directories with progress summaries.
+- Integrate optional cloud storage backends for remote payload retrieval.
+- Support external key management systems for passwordless encryption.


### PR DESCRIPTION
## Summary
- mention `setup.sh` helper in README install steps
- add new ideas to the proposals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685e75d0feac832bb38fbf3e5f376c93

## Summary by Sourcery

Update setup documentation to include the setup.sh helper and expand the proposals with new feature ideas

Documentation:
- Mention the setup.sh helper script in the README’s install steps
- Add proposal ideas for batch processing mode, cloud storage backends, and key management system support