### PR TITLE
Add LICENSE and update proposals

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 elithaxxor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/proposals.md
+++ b/proposals.md
@@ -14,3 +14,7 @@
 - Package the tool using PyInstaller for easy distribution.
 - Implement optional in-memory encryption for sensitive payloads.
 - Provide a plugin marketplace to share community extensions.
+
+- Support distributed scanning across remote workers.
+- Integrate GPU acceleration for compute-intensive algorithms.
+- Provide cross-platform desktop packaging for macOS and Windows.


### PR DESCRIPTION
## Summary
- add missing MIT License referenced in README
- extend project proposals with additional features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_685e75d1dd70832b90fc9368ab1c7865

## Summary by Sourcery

Add an MIT license file and update project proposals with additional feature ideas

Documentation:
- Add a LICENSE file containing the MIT license
- Extend proposals.md with entries for distributed scanning, GPU acceleration, and cross-platform desktop packaging