### PR TITLE
Add offline wheel installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ pip install -r requirements.txt
 
 # Or run the helper script to create a virtual environment
 bash setup.sh
+
+# Offline install (no internet)
+bash offline_install.sh
 ```
 
 ### Option 2: Download ZIP
@@ -216,6 +219,10 @@ bash setup.sh
 3. Extract the ZIP file to your preferred location
 4. Open a terminal/command prompt in the extracted directory
 5. Run `pip install -r requirements.txt`
+6. Offline install (no internet):
+   ```bash
+   bash offline_install.sh
+   ```
 
 <details>
 <summary>📋 View dependencies (requirements.txt)</summary>

--- a/offline_install.sh
+++ b/offline_install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Install Python package wheels from local vendor directory without internet.
+
+set -e
+
+if [ ! -d "vendor" ]; then
+  echo "Vendor directory not found. Please place wheel files in ./vendor" >&2
+  exit 1
+fi
+
+pip install --no-index --find-links=vendor -r requirements.txt

--- a/proposals.md
+++ b/proposals.md
@@ -25,3 +25,5 @@
 - Add batch processing mode for entire directories with progress summaries.
 - Integrate optional cloud storage backends for remote payload retrieval.
 - Support external key management systems for passwordless encryption.
+- Bundle Python wheel dependencies in a `vendor/` folder and provide an
+  `offline_install.sh` script for air-gapped environments.

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,2 @@
+Place pre-downloaded wheel files for dependencies in this directory.
+Running `bash offline_install.sh` installs them without internet access.


### PR DESCRIPTION
## Summary
- add `offline_install.sh` script for offline dependency setup
- document offline installation steps in README
- store vendor folder with README
- propose bundling wheels in future development proposals

## Testing
- `bash offline_install.sh` *(fails: could not find packages)*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError for cryptography)*

------
https://chatgpt.com/codex/tasks/task_e_685f59708c58832b9c49578613931fe8

## Summary by Sourcery

Enable offline dependency setup by introducing an offline_install.sh script, bundling wheel files in a vendor folder, and updating documentation to guide air-gapped installations

New Features:
- Add offline_install.sh script to install Python dependencies from a local vendor directory without internet

Documentation:
- Document offline installation steps in the main README
- Update proposals to recommend bundling wheels for air-gapped environments
- Add a README to the vendor directory for wheel placement guidance