### PR TITLE
Add ignore rules and update proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+.env.*
+
+# virtualenv
+venv/
+ENV/
+env/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# VS Code
+.vscode/
+
+# Mac OS
+.DS_Store
+
+# Temporary files
+*.tmp
+*.bak
+*.swp
+
+# Local docker artifacts
+*.img
+

--- a/proposals.md
+++ b/proposals.md
@@ -33,3 +33,6 @@ automated CI and the web interface have already been implemented.
 
 - Bundle Python wheel dependencies in a `vendor/` folder and provide an
   `offline_install.sh` script for air-gapped environments.
+- Add a DCT-based image plugin for JPEG steganography.
+- Integrate a password manager API for secure credential storage.
+- Command line 'wizard' mode for simplified operations.


### PR DESCRIPTION
## Summary
- ignore virtual environments and caches
- outline additional feature ideas

## Testing
- `flake8 stego_plugins stego.py api.py GUI || true`
- `pip-audit -r requirements.txt || true`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685f80155b34832bb228a820c55bf411

## Summary by Sourcery

Add .gitignore to exclude virtual environments and cache files, and expand the feature proposals document with three new enhancement ideas.

Documentation:
- Update proposals.md to suggest a DCT-based image steganography plugin, password manager API integration, and a command-line wizard mode.

Chores:
- Add .gitignore to ignore virtual environment and cache directories.