### PR TITLE
Update docs for plugin paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,20 @@ will automatically download it from the public release URL on first use.
 No manual steps are required—simply invoke the plugin and the model will
 be retrieved and saved alongside the other plugins.
 
+### Third-Party Plugins
+
+You can extend the tool by loading external plugins from custom directories.
+Set the `STEGO_PLUGIN_PATH` environment variable to point to one or more
+locations that contain your plugin modules (use `:` to separate paths on
+Linux/macOS or `;` on Windows).
+
+```bash
+# Example: load plugins from two directories
+export STEGO_PLUGIN_PATH="/opt/stego_plugins:$HOME/my_plugins"
+stego.py plugin --tool myplugin \
+       --action embed -i cover.png -p secret.txt -o hidden.png
+```
+
 ---
 
 ## 📱 Usage Guide


### PR DESCRIPTION
## Summary
- document how to load third-party plugins via `STEGO_PLUGIN_PATH`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685f8018bf78832b9e18ba3918ff2661

## Summary by Sourcery

Document how to load external plugins via STEGO_PLUGIN_PATH in the README

Documentation:
- Add a “Third-Party Plugins” section explaining how to set STEGO_PLUGIN_PATH and load plugins
- Include an example command showing multiple plugin directories on Linux/macOS and Windows