### PR TITLE
Add flake8 check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
       - run: pip install flake8
       - run: pip install pip-audit
       - run: pip-audit -r requirements.txt
-      - run: flake8 stego_plugins stego.py api.py GUI || true
+      - run: flake8 stego_plugins stego.py api.py GUI
       - run: pytest -q


### PR DESCRIPTION
## Summary
- run flake8 in CI without ignoring failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685f801d9734832bb46e8057c9d1d36a

## Summary by Sourcery

CI:
- Install flake8 in the CI pipeline and remove the ignore setting so that lint errors break the build.