### PR TITLE
Fix requirements and extend proposals

### DIFF
--- a/proposals.md
+++ b/proposals.md
@@ -31,5 +31,10 @@ automated CI and the web interface have already been implemented.
 - Visualization of detection results with interactive charts.
 - Plugin sandboxing using subprocess isolation.
 
+- Verify critical dependencies like `cryptography` during CI setup to avoid
+  missing-package errors.
+- Add optional logging plugin to track usage statistics while preserving
+  user privacy through anonymization.
+
 - Bundle Python wheel dependencies in a `vendor/` folder and provide an
   `offline_install.sh` script for air-gapped environments.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama
 psutil
-cryptography
+cryptography>=3.4.7
 PyPDF2
 qrcode
 pyzbar


### PR DESCRIPTION
## Summary
- pin `cryptography` dependency so CI installs it reliably
- list new enhancement ideas for tracking dependencies and logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685f802065f4832bbcab689a9290899e

## Summary by Sourcery

Pin the cryptography dependency to avoid CI install failures and extend the project proposals to include CI dependency verification and an anonymized logging plugin.

Build:
- Pin cryptography to version >=3.4.7 in requirements.txt to prevent missing-package errors during CI.

Documentation:
- Add proposals to verify critical dependencies during CI setup.
- Add a proposal for an optional anonymized logging plugin to track usage statistics.